### PR TITLE
Fix export as image

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -12,6 +12,7 @@ RUN  --mount=type=cache,target=/root/.gradle ./gradlew clean build -x test
 RUN mkdir -p build/dependency && (cd build/dependency; jar -xf ../libs/*.jar)
 
 FROM openjdk:8-jdk-alpine
+RUN apk add --no-cache fontconfig ttf-dejavu
 VOLUME /tmp
 ARG DEPENDENCY=/workspace/app/build/dependency
 COPY --from=build ${DEPENDENCY}/BOOT-INF/lib /app/lib

--- a/backend/src/main/java/com/bulletjournal/messaging/OpenHtmlConverter.java
+++ b/backend/src/main/java/com/bulletjournal/messaging/OpenHtmlConverter.java
@@ -31,11 +31,20 @@ public class OpenHtmlConverter {
 
   /**
    * convert project item as `png` image
+   * <p>
+   * <b>Note</b>
+   *  Converted project item image won't contain any [img] tag.
+   *  - `openhtmltopdf-java2d` image converter only supports limit image format,
+   *  - image inside [img] may cause unexpected error when export project item as image
+   * </p>
    */
   public static ByteArrayResource projectItemHtmlToImage(String html, double scale) throws Exception {
     ByteArrayOutputStream os = new ByteArrayOutputStream();
 
-    IMAGE_BUILDER.withHtmlContent(htmlToXhtml(html), null);
+    String htmlWithoutImage = htmlToXhtml(html)
+            .replaceAll("<img .*? ((/>)|(</img>))", "");
+
+    IMAGE_BUILDER.withHtmlContent(htmlWithoutImage, null);
     IMAGE_BUILDER.useFastMode();
     IMAGE_BUILDER.useEnvironmentFonts(true);
 
@@ -54,7 +63,7 @@ public class OpenHtmlConverter {
   }
 
   public static ByteArrayResource projectItemHtmlToImageForPC(String html) throws Exception {
-    return projectItemHtmlToImage(html, 10);
+    return projectItemHtmlToImage(html, 5);
   }
 
   /**


### PR DESCRIPTION
## Fix Export As Image Error within Docker

Changes
- Add `fontconfig` when building  backend docker image 
- Remove `<img>` tag from project item contents
- Slightly reduce output image size for PC. 