### PR TITLE
note_auditables

### DIFF
--- a/backend/src/main/java/com/bulletjournal/controller/models/ProjectItemActivity.java
+++ b/backend/src/main/java/com/bulletjournal/controller/models/ProjectItemActivity.java
@@ -1,0 +1,61 @@
+package com.bulletjournal.controller.models;
+
+import com.bulletjournal.contents.ContentAction;
+
+public class ProjectItemActivity {
+
+  private User originator;
+  private String activity;
+  private Long activityTime;
+  private ContentAction action;
+  private String beforeActivity;
+  private String afterActivity;
+
+  public User getOriginator() {
+    return originator;
+  }
+
+  public void setOriginator(User originator) {
+    this.originator = originator;
+  }
+
+  public String getActivity() {
+    return activity;
+  }
+
+  public void setActivity(String activity) {
+    this.activity = activity;
+  }
+
+  public ContentAction getAction() {
+    return action;
+  }
+
+  public void setAction(ContentAction action) {
+    this.action = action;
+  }
+
+  public Long getActivityTime() {
+    return activityTime;
+  }
+
+  public void setActivityTime(Long activityTime) {
+    this.activityTime = activityTime;
+  }
+
+  public String getBeforeActivity() {
+    return beforeActivity;
+  }
+
+  public void setBeforeActivity(String beforeActivity) {
+    this.beforeActivity = beforeActivity;
+  }
+
+  public String getAfterActivity() {
+    return afterActivity;
+  }
+
+  public void setAfterActivity(String afterActivity) {
+    this.afterActivity = afterActivity;
+  }
+}

--- a/backend/src/main/java/com/bulletjournal/notifications/NoteAuditable.java
+++ b/backend/src/main/java/com/bulletjournal/notifications/NoteAuditable.java
@@ -1,0 +1,46 @@
+package com.bulletjournal.notifications;
+
+import com.bulletjournal.contents.ContentAction;
+import com.bulletjournal.repository.models.Note;
+
+import java.sql.Timestamp;
+
+public class NoteAuditable extends ProjectItemAuditableModel {
+  private Note note;
+
+  public NoteAuditable(
+      Note note,
+      String beforeActivity,
+      String afterActivity,
+      String activity,
+      String originator,
+      ContentAction action,
+      Timestamp activityTime) {
+    this.note = note;
+    this.beforeActivity = beforeActivity;
+    this.afterActivity = afterActivity;
+    this.activity = activity;
+    this.originator = originator;
+    this.action = action;
+    this.activityTime = activityTime;
+  }
+
+  public com.bulletjournal.repository.models.NoteAuditable toRepositoryAuditable() {
+    return new com.bulletjournal.repository.models.NoteAuditable(
+        this.note,
+        this.activity,
+        this.originator,
+        this.activityTime,
+        this.action,
+        this.beforeActivity,
+        this.afterActivity);
+  }
+
+  public Note getNote() {
+    return note;
+  }
+
+  public void setNote(Note note) {
+    this.note = note;
+  }
+}

--- a/backend/src/main/java/com/bulletjournal/notifications/NotificationService.java
+++ b/backend/src/main/java/com/bulletjournal/notifications/NotificationService.java
@@ -30,10 +30,13 @@ public class NotificationService {
     private final BlockingQueue<Object> eventQueue;
     private final NotificationDaoJpa notificationDaoJpa;
     private final AuditableDaoJpa auditableDaoJpa;
-    private final NoteAuditableDaoJpa noteAuditableDaoJpa;
     private final SearchIndexDaoJpa searchIndexDaoJpa;
     private final RedisEtagDaoJpa redisEtagDaoJpa;
     private volatile boolean stop = false;
+
+    @Autowired
+    @Lazy
+    private NoteAuditableDaoJpa noteAuditableDaoJpa;
 
     @Autowired
     private SpringESConfig springESConfig;
@@ -61,11 +64,9 @@ public class NotificationService {
 
     @Autowired
     public NotificationService(NotificationDaoJpa notificationDaoJpa, AuditableDaoJpa auditableDaoJpa,
-                               NoteAuditableDaoJpa noteAuditableDaoJpa,
                                SearchIndexDaoJpa searchIndexDaoJpa, RedisEtagDaoJpa redisEtagDaoJpa) {
         this.notificationDaoJpa = notificationDaoJpa;
         this.auditableDaoJpa = auditableDaoJpa;
-        this.noteAuditableDaoJpa = noteAuditableDaoJpa;
         this.searchIndexDaoJpa = searchIndexDaoJpa;
         this.redisEtagDaoJpa = redisEtagDaoJpa;
         this.executorService = Executors.newSingleThreadExecutor(new CustomThreadFactory("notification-service"));

--- a/backend/src/main/java/com/bulletjournal/notifications/ProjectItemAuditableModel.java
+++ b/backend/src/main/java/com/bulletjournal/notifications/ProjectItemAuditableModel.java
@@ -5,6 +5,11 @@ import com.bulletjournal.contents.ContentAction;
 import java.sql.Timestamp;
 
 public abstract class ProjectItemAuditableModel {
+  public static final String PROJECT_NAME_PROPERTY = "projectName";
+  public static final String PROJECT_ITEM_PROPERTY = "projectItem";
+  public static final String PROJECT_CONTENT_PROPERTY = "projectContent";
+  public static final String EMPTY_VALUE = "{}";
+
   protected String beforeActivity;
   protected String afterActivity;
   protected String activity;

--- a/backend/src/main/java/com/bulletjournal/notifications/ProjectItemAuditableModel.java
+++ b/backend/src/main/java/com/bulletjournal/notifications/ProjectItemAuditableModel.java
@@ -5,10 +5,8 @@ import com.bulletjournal.contents.ContentAction;
 import java.sql.Timestamp;
 
 public abstract class ProjectItemAuditableModel {
-  public static final String PROJECT_NAME_PROPERTY = "projectName";
   public static final String PROJECT_ITEM_PROPERTY = "projectItem";
   public static final String PROJECT_CONTENT_PROPERTY = "projectContent";
-  public static final String EMPTY_VALUE = "{}";
 
   protected String beforeActivity;
   protected String afterActivity;

--- a/backend/src/main/java/com/bulletjournal/notifications/ProjectItemAuditableModel.java
+++ b/backend/src/main/java/com/bulletjournal/notifications/ProjectItemAuditableModel.java
@@ -6,7 +6,7 @@ import java.sql.Timestamp;
 
 public abstract class ProjectItemAuditableModel {
   public static final String PROJECT_ITEM_PROPERTY = "projectItem";
-  public static final String PROJECT_CONTENT_PROPERTY = "projectContent";
+  public static final String CONTENT_PROPERTY = "content";
 
   protected String beforeActivity;
   protected String afterActivity;

--- a/backend/src/main/java/com/bulletjournal/notifications/ProjectItemAuditableModel.java
+++ b/backend/src/main/java/com/bulletjournal/notifications/ProjectItemAuditableModel.java
@@ -1,0 +1,62 @@
+package com.bulletjournal.notifications;
+
+import com.bulletjournal.contents.ContentAction;
+
+import java.sql.Timestamp;
+
+public abstract class ProjectItemAuditableModel {
+  protected String beforeActivity;
+  protected String afterActivity;
+  protected String activity;
+  protected String originator;
+  protected ContentAction action;
+  protected Timestamp activityTime;
+
+  public String getBeforeActivity() {
+    return beforeActivity;
+  }
+
+  public void setBeforeActivity(String beforeActivity) {
+    this.beforeActivity = beforeActivity;
+  }
+
+  public String getAfterActivity() {
+    return afterActivity;
+  }
+
+  public void setAfterActivity(String afterActivity) {
+    this.afterActivity = afterActivity;
+  }
+
+  public String getActivity() {
+    return activity;
+  }
+
+  public void setActivity(String activity) {
+    this.activity = activity;
+  }
+
+  public String getOriginator() {
+    return originator;
+  }
+
+  public void setOriginator(String originator) {
+    this.originator = originator;
+  }
+
+  public ContentAction getAction() {
+    return action;
+  }
+
+  public void setAction(ContentAction action) {
+    this.action = action;
+  }
+
+  public Timestamp getActivityTime() {
+    return activityTime;
+  }
+
+  public void setActivityTime(Timestamp activityTime) {
+    this.activityTime = activityTime;
+  }
+}

--- a/backend/src/main/java/com/bulletjournal/repository/NoteAuditableDaoJpa.java
+++ b/backend/src/main/java/com/bulletjournal/repository/NoteAuditableDaoJpa.java
@@ -1,0 +1,23 @@
+package com.bulletjournal.repository;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Repository
+public class NoteAuditableDaoJpa {
+
+  @Autowired private NoteAuditableRepository noteAuditableRepository;
+
+  @Transactional(rollbackFor = Exception.class, propagation = Propagation.REQUIRED)
+  public void create(List<com.bulletjournal.notifications.NoteAuditable> noteAuditables) {
+    this.noteAuditableRepository.saveAll(
+        noteAuditables.stream()
+            .map(com.bulletjournal.notifications.NoteAuditable::toRepositoryAuditable)
+            .collect(Collectors.toList()));
+  }
+}

--- a/backend/src/main/java/com/bulletjournal/repository/NoteAuditableDaoJpa.java
+++ b/backend/src/main/java/com/bulletjournal/repository/NoteAuditableDaoJpa.java
@@ -1,6 +1,11 @@
 package com.bulletjournal.repository;
 
+import com.bulletjournal.controller.models.ProjectItemActivity;
+import com.bulletjournal.repository.models.NoteAuditable;
+import com.bulletjournal.repository.models.ProjectItemAuditModel;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,5 +24,16 @@ public class NoteAuditableDaoJpa {
         noteAuditables.stream()
             .map(com.bulletjournal.notifications.NoteAuditable::toRepositoryAuditable)
             .collect(Collectors.toList()));
+  }
+
+  @Transactional(rollbackFor = Exception.class, propagation = Propagation.REQUIRED)
+  public List<ProjectItemActivity> getHistory(Long noteId, int pageInd, int pageSize) {
+
+    List<NoteAuditable> hist =
+        this.noteAuditableRepository.findAllByNoteId(
+            noteId, PageRequest.of(pageInd, pageSize, Sort.by("activityTime").descending()));
+    return hist.stream()
+        .map(ProjectItemAuditModel::toProjectItemActivity)
+        .collect(Collectors.toList());
   }
 }

--- a/backend/src/main/java/com/bulletjournal/repository/NoteAuditableDaoJpa.java
+++ b/backend/src/main/java/com/bulletjournal/repository/NoteAuditableDaoJpa.java
@@ -1,9 +1,8 @@
 package com.bulletjournal.repository;
 
-import com.bulletjournal.controller.models.ProjectItemActivity;
 import com.bulletjournal.repository.models.NoteAuditable;
-import com.bulletjournal.repository.models.ProjectItemAuditModel;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
@@ -27,13 +26,8 @@ public class NoteAuditableDaoJpa {
   }
 
   @Transactional(rollbackFor = Exception.class, propagation = Propagation.REQUIRED)
-  public List<ProjectItemActivity> getHistory(Long noteId, int pageInd, int pageSize) {
-
-    List<NoteAuditable> hist =
-        this.noteAuditableRepository.findAllByNoteId(
-            noteId, PageRequest.of(pageInd, pageSize, Sort.by("activityTime").descending()));
-    return hist.stream()
-        .map(ProjectItemAuditModel::toProjectItemActivity)
-        .collect(Collectors.toList());
+  public Page<NoteAuditable> getHistory(Long noteId, int pageInd, int pageSize) {
+    return this.noteAuditableRepository.findAllByNoteId(
+        noteId, PageRequest.of(pageInd, pageSize, Sort.by("activityTime").descending()));
   }
 }

--- a/backend/src/main/java/com/bulletjournal/repository/NoteAuditableRepository.java
+++ b/backend/src/main/java/com/bulletjournal/repository/NoteAuditableRepository.java
@@ -1,9 +1,13 @@
 package com.bulletjournal.repository;
 
 import com.bulletjournal.repository.models.NoteAuditable;
-import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
-public interface NoteAuditableRepository extends JpaRepository<NoteAuditable, Long> {
+public interface NoteAuditableRepository extends PagingAndSortingRepository<NoteAuditable, Long> {
+    List<NoteAuditable> findAllByNoteId(Long noteId, Pageable pageable);
 }

--- a/backend/src/main/java/com/bulletjournal/repository/NoteAuditableRepository.java
+++ b/backend/src/main/java/com/bulletjournal/repository/NoteAuditableRepository.java
@@ -1,0 +1,9 @@
+package com.bulletjournal.repository;
+
+import com.bulletjournal.repository.models.NoteAuditable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NoteAuditableRepository extends JpaRepository<NoteAuditable, Long> {
+}

--- a/backend/src/main/java/com/bulletjournal/repository/NoteAuditableRepository.java
+++ b/backend/src/main/java/com/bulletjournal/repository/NoteAuditableRepository.java
@@ -1,13 +1,12 @@
 package com.bulletjournal.repository;
 
 import com.bulletjournal.repository.models.NoteAuditable;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
-
 @Repository
 public interface NoteAuditableRepository extends PagingAndSortingRepository<NoteAuditable, Long> {
-    List<NoteAuditable> findAllByNoteId(Long noteId, Pageable pageable);
+    Page<NoteAuditable> findAllByNoteId(Long noteId, Pageable pageable);
 }

--- a/backend/src/main/java/com/bulletjournal/repository/NoteDaoJpa.java
+++ b/backend/src/main/java/com/bulletjournal/repository/NoteDaoJpa.java
@@ -42,6 +42,9 @@ import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import static com.bulletjournal.notifications.ProjectItemAuditableModel.PROJECT_ITEM_PROPERTY;
+import static com.bulletjournal.notifications.ProjectItemAuditableModel.PROJECT_NAME_PROPERTY;
+
 @Repository
 public class NoteDaoJpa extends ProjectItemDaoJpa<NoteContent> {
     private static final Logger LOGGER = LoggerFactory.getLogger(NoteDaoJpa.class);
@@ -192,8 +195,8 @@ public class NoteDaoJpa extends ProjectItemDaoJpa<NoteContent> {
         this.notificationService.trackNoteActivity(
             new com.bulletjournal.notifications.NoteAuditable(
                 note,
-                new JSONObject().put("projectItem", noteBeforeUpdate).toString(),
-                new JSONObject().put("projectItem", noteAfterUpdate).toString(),
+                new JSONObject().put(PROJECT_ITEM_PROPERTY, noteBeforeUpdate).toString(),
+                new JSONObject().put(PROJECT_ITEM_PROPERTY, noteAfterUpdate).toString(),
                 "updated note ##" + note.getName() + "## in BuJo ##" + note.getProject().getName() + "##",
                 requester,
                 ContentAction.UPDATE_NOTE,
@@ -280,8 +283,8 @@ public class NoteDaoJpa extends ProjectItemDaoJpa<NoteContent> {
         this.notificationService.trackNoteActivity(
             new com.bulletjournal.notifications.NoteAuditable(
                 note,
-                new JSONObject().put("projectName", projNameBeforeUpdate).toString(),
-                new JSONObject().put("projectName", projNameAfterUpdate).toString(),
+                new JSONObject().put(PROJECT_NAME_PROPERTY, projNameBeforeUpdate).toString(),
+                new JSONObject().put(PROJECT_NAME_PROPERTY, projNameAfterUpdate).toString(),
                 "moved note ##" + note.getName() + "## from BuJo ##" + projNameBeforeUpdate + "## to BuJo ##"
                     + projNameAfterUpdate + "##",
                 requester,

--- a/backend/src/main/java/com/bulletjournal/repository/NoteDaoJpa.java
+++ b/backend/src/main/java/com/bulletjournal/repository/NoteDaoJpa.java
@@ -15,7 +15,6 @@ import com.bulletjournal.exceptions.BadRequestException;
 import com.bulletjournal.hierarchy.HierarchyItem;
 import com.bulletjournal.hierarchy.HierarchyProcessor;
 import com.bulletjournal.hierarchy.NoteRelationsProcessor;
-import com.bulletjournal.notifications.Auditable;
 import com.bulletjournal.notifications.Event;
 import com.bulletjournal.notifications.NotificationService;
 import com.bulletjournal.repository.models.*;

--- a/backend/src/main/java/com/bulletjournal/repository/NoteDaoJpa.java
+++ b/backend/src/main/java/com/bulletjournal/repository/NoteDaoJpa.java
@@ -42,7 +42,6 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import static com.bulletjournal.notifications.ProjectItemAuditableModel.PROJECT_ITEM_PROPERTY;
-import static com.bulletjournal.notifications.ProjectItemAuditableModel.PROJECT_NAME_PROPERTY;
 
 @Repository
 public class NoteDaoJpa extends ProjectItemDaoJpa<NoteContent> {

--- a/backend/src/main/java/com/bulletjournal/repository/NoteDaoJpa.java
+++ b/backend/src/main/java/com/bulletjournal/repository/NoteDaoJpa.java
@@ -266,7 +266,6 @@ public class NoteDaoJpa extends ProjectItemDaoJpa<NoteContent> {
         final Project project = this.projectDaoJpa.getProject(targetProject, requester);
 
         Note note = this.getProjectItem(noteId, requester);
-        String projNameBeforeUpdate = note.getProject().getName();
 
         if (!Objects.equals(note.getProject().getType(), project.getType())) {
             throw new BadRequestException("Cannot move to Project Type " + project.getType());
@@ -277,20 +276,6 @@ public class NoteDaoJpa extends ProjectItemDaoJpa<NoteContent> {
 
         note.setProject(project);
         noteRepository.save(note);
-
-        String projNameAfterUpdate = note.getProject().getName();
-        this.notificationService.trackNoteActivity(
-            new com.bulletjournal.notifications.NoteAuditable(
-                note,
-                new JSONObject().put(PROJECT_NAME_PROPERTY, projNameBeforeUpdate).toString(),
-                new JSONObject().put(PROJECT_NAME_PROPERTY, projNameAfterUpdate).toString(),
-                "moved note ##" + note.getName() + "## from BuJo ##" + projNameBeforeUpdate + "## to BuJo ##"
-                    + projNameAfterUpdate + "##",
-                requester,
-                ContentAction.MOVE_NOTE,
-                Timestamp.from(Instant.now())
-            )
-        );
 
         return Pair.of(note, project);
     }

--- a/backend/src/main/java/com/bulletjournal/repository/NoteDaoJpa.java
+++ b/backend/src/main/java/com/bulletjournal/repository/NoteDaoJpa.java
@@ -14,7 +14,9 @@ import com.bulletjournal.exceptions.BadRequestException;
 import com.bulletjournal.hierarchy.HierarchyItem;
 import com.bulletjournal.hierarchy.HierarchyProcessor;
 import com.bulletjournal.hierarchy.NoteRelationsProcessor;
+import com.bulletjournal.notifications.Auditable;
 import com.bulletjournal.notifications.Event;
+import com.bulletjournal.notifications.NotificationService;
 import com.bulletjournal.repository.models.*;
 import com.bulletjournal.repository.utils.DaoHelper;
 import org.apache.commons.lang3.StringUtils;
@@ -56,6 +58,8 @@ public class NoteDaoJpa extends ProjectItemDaoJpa<NoteContent> {
     private SharedProjectItemDaoJpa sharedProjectItemDaoJpa;
     @Autowired
     private SearchIndexDaoJpa searchIndexDaoJpa;
+    @Autowired
+    protected NotificationService notificationService;
 
     @Override
     public JpaRepository getJpaRepository() {
@@ -174,6 +178,10 @@ public class NoteDaoJpa extends ProjectItemDaoJpa<NoteContent> {
         if (updateNoteParams.hasLabels()) {
             note.setLabels(updateNoteParams.getLabels());
         }
+
+        this.notificationService.trackActivity(
+                new Auditable(note,
+                        )
 
         return this.noteRepository.save(note);
     }

--- a/backend/src/main/java/com/bulletjournal/repository/ProjectItemDaoJpa.java
+++ b/backend/src/main/java/com/bulletjournal/repository/ProjectItemDaoJpa.java
@@ -221,19 +221,6 @@ public abstract class ProjectItemDaoJpa<K extends ContentModel> {
         populateContent(owner, content, projectItem);
         this.getContentJpaRepository().save(content);
 
-        if (projectItem.getContentType() == ContentType.NOTE) {
-            this.notificationService.trackNoteActivity(
-                new com.bulletjournal.notifications.NoteAuditable(
-                    (com.bulletjournal.repository.models.Note) projectItem,
-                    new JSONObject().put(PROJECT_CONTENT_PROPERTY, EMPTY_VALUE).toString(),
-                    new JSONObject().put(PROJECT_CONTENT_PROPERTY, GSON.toJson(content.toPresentationModel())).toString(),
-                    "added content to note ##" + projectItem.getName() + "##",
-                    owner,
-                    ContentAction.ADD_NOTE_CONTENT,
-                    Timestamp.from(Instant.now())
-                )
-            );
-        }
         return Pair.of(content, projectItem);
     }
 

--- a/backend/src/main/java/com/bulletjournal/repository/ProjectItemDaoJpa.java
+++ b/backend/src/main/java/com/bulletjournal/repository/ProjectItemDaoJpa.java
@@ -47,6 +47,9 @@ import java.time.Instant;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import static com.bulletjournal.notifications.ProjectItemAuditableModel.EMPTY_VALUE;
+import static com.bulletjournal.notifications.ProjectItemAuditableModel.PROJECT_CONTENT_PROPERTY;
+
 public abstract class ProjectItemDaoJpa<K extends ContentModel> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ProjectItemDaoJpa.class);
@@ -222,8 +225,8 @@ public abstract class ProjectItemDaoJpa<K extends ContentModel> {
             this.notificationService.trackNoteActivity(
                 new com.bulletjournal.notifications.NoteAuditable(
                     (com.bulletjournal.repository.models.Note) projectItem,
-                    new JSONObject().put("projectContent", "\"\"").toString(),
-                    new JSONObject().put("projectContent", GSON.toJson(content.toPresentationModel())).toString(),
+                    new JSONObject().put(PROJECT_CONTENT_PROPERTY, EMPTY_VALUE).toString(),
+                    new JSONObject().put(PROJECT_CONTENT_PROPERTY, GSON.toJson(content.toPresentationModel())).toString(),
                     "added content to note ##" + projectItem.getName() + "##",
                     owner,
                     ContentAction.ADD_NOTE_CONTENT,
@@ -299,8 +302,8 @@ public abstract class ProjectItemDaoJpa<K extends ContentModel> {
             this.notificationService.trackNoteActivity(
                 new com.bulletjournal.notifications.NoteAuditable(
                     (com.bulletjournal.repository.models.Note) projectItem,
-                    new JSONObject().put("projectContent", contentBeforeUpdate).toString(),
-                    new JSONObject().put("projectContent", contentAfterUpdate).toString(),
+                    new JSONObject().put(PROJECT_CONTENT_PROPERTY, contentBeforeUpdate).toString(),
+                    new JSONObject().put(PROJECT_CONTENT_PROPERTY, contentAfterUpdate).toString(),
                     "updated note content in ##" + projectItem.getName() + "##",
                     requester,
                     ContentAction.UPDATE_NOTE_CONTENT,
@@ -357,8 +360,8 @@ public abstract class ProjectItemDaoJpa<K extends ContentModel> {
             this.notificationService.trackNoteActivity(
                 new com.bulletjournal.notifications.NoteAuditable(
                     (com.bulletjournal.repository.models.Note) projectItem,
-                    new JSONObject().put("projectContent", GSON.toJson(content.toPresentationModel())).toString(),
-                    new JSONObject().put("projectContent", "\"\"").toString(),
+                    new JSONObject().put(PROJECT_CONTENT_PROPERTY, GSON.toJson(content.toPresentationModel())).toString(),
+                    new JSONObject().put(PROJECT_CONTENT_PROPERTY, EMPTY_VALUE).toString(),
                     "deleted note content in ##" + projectItem.getName() + "##",
                     requester,
                     ContentAction.DELETE_NOTE_CONTENT,

--- a/backend/src/main/java/com/bulletjournal/repository/ProjectItemDaoJpa.java
+++ b/backend/src/main/java/com/bulletjournal/repository/ProjectItemDaoJpa.java
@@ -345,8 +345,8 @@ public abstract class ProjectItemDaoJpa<K extends ContentModel> {
             this.notificationService.trackNoteActivity(
                 new com.bulletjournal.notifications.NoteAuditable(
                     (com.bulletjournal.repository.models.Note) projectItem,
-                    new JSONObject().put(PROJECT_CONTENT_PROPERTY, GSON.toJson(content.toPresentationModel())).toString(),
-                    new JSONObject().put(PROJECT_CONTENT_PROPERTY, EMPTY_VALUE).toString(),
+                    new JSONObject().put(PROJECT_CONTENT_PROPERTY, content.getBaseText()).toString(),
+                    null,
                     "deleted note content in ##" + projectItem.getName() + "##",
                     requester,
                     ContentAction.DELETE_NOTE_CONTENT,

--- a/backend/src/main/java/com/bulletjournal/repository/ProjectItemDaoJpa.java
+++ b/backend/src/main/java/com/bulletjournal/repository/ProjectItemDaoJpa.java
@@ -352,6 +352,20 @@ public abstract class ProjectItemDaoJpa<K extends ContentModel> {
                 Operation.DELETE, content.getId(), projectItem.getOwner(), projectItem.getProject().getOwner(),
                 projectItem);
         this.getContentJpaRepository().delete(content);
+
+        if (projectItem.getContentType() == ContentType.NOTE) {
+            this.notificationService.trackNoteActivity(
+                new com.bulletjournal.notifications.NoteAuditable(
+                    (com.bulletjournal.repository.models.Note) projectItem,
+                    new JSONObject().put("projectContent", GSON.toJson(content.toPresentationModel())).toString(),
+                    new JSONObject().put("projectContent", "\"\"").toString(),
+                    "deleted note content in ##" + projectItem.getName() + "##",
+                    requester,
+                    ContentAction.DELETE_NOTE_CONTENT,
+                    Timestamp.from(Instant.now())
+                )
+            );
+        }
         return projectItem;
     }
 

--- a/backend/src/main/java/com/bulletjournal/repository/ProjectItemDaoJpa.java
+++ b/backend/src/main/java/com/bulletjournal/repository/ProjectItemDaoJpa.java
@@ -260,8 +260,6 @@ public abstract class ProjectItemDaoJpa<K extends ContentModel> {
                 Operation.UPDATE, content.getId(), projectItem.getOwner(), projectItem.getProject().getOwner(),
                 projectItem);
 
-        String contentBeforeUpdate = GSON.toJson(content.toPresentationModel());
-
         String oldText = content.getText();
         if (etag.isPresent()) {
             String itemEtag = EtagGenerator.generateEtag(EtagGenerator.HashAlgorithm.MD5,
@@ -283,13 +281,13 @@ public abstract class ProjectItemDaoJpa<K extends ContentModel> {
         this.getJpaRepository().save(projectItem);
 
         Pair<K, T> res = updateContent(requester, updateContentParams, projectItem, content, oldText);
-        String contentAfterUpdate = GSON.toJson(res.getLeft().toPresentationModel());
+        String contentAfterUpdate = res.getLeft().getBaseText();
 
         if (projectItem.getContentType() == ContentType.NOTE) {
             this.notificationService.trackNoteActivity(
                 new com.bulletjournal.notifications.NoteAuditable(
                     (com.bulletjournal.repository.models.Note) projectItem,
-                    new JSONObject().put(PROJECT_CONTENT_PROPERTY, contentBeforeUpdate).toString(),
+                    null,
                     new JSONObject().put(PROJECT_CONTENT_PROPERTY, contentAfterUpdate).toString(),
                     "updated note content in ##" + projectItem.getName() + "##",
                     requester,

--- a/backend/src/main/java/com/bulletjournal/repository/ProjectItemDaoJpa.java
+++ b/backend/src/main/java/com/bulletjournal/repository/ProjectItemDaoJpa.java
@@ -47,7 +47,6 @@ import java.time.Instant;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import static com.bulletjournal.notifications.ProjectItemAuditableModel.EMPTY_VALUE;
 import static com.bulletjournal.notifications.ProjectItemAuditableModel.PROJECT_CONTENT_PROPERTY;
 
 public abstract class ProjectItemDaoJpa<K extends ContentModel> {

--- a/backend/src/main/java/com/bulletjournal/repository/ProjectItemDaoJpa.java
+++ b/backend/src/main/java/com/bulletjournal/repository/ProjectItemDaoJpa.java
@@ -47,7 +47,7 @@ import java.time.Instant;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import static com.bulletjournal.notifications.ProjectItemAuditableModel.PROJECT_CONTENT_PROPERTY;
+import static com.bulletjournal.notifications.ProjectItemAuditableModel.CONTENT_PROPERTY;
 
 public abstract class ProjectItemDaoJpa<K extends ContentModel> {
 
@@ -286,8 +286,8 @@ public abstract class ProjectItemDaoJpa<K extends ContentModel> {
             this.notificationService.trackNoteActivity(
                 new com.bulletjournal.notifications.NoteAuditable(
                     (com.bulletjournal.repository.models.Note) projectItem,
-                    new JSONObject().put(PROJECT_CONTENT_PROPERTY, oldText).toString(),
-                    new JSONObject().put(PROJECT_CONTENT_PROPERTY, newText).toString(),
+                    new JSONObject().put(CONTENT_PROPERTY, oldText).toString(),
+                    new JSONObject().put(CONTENT_PROPERTY, newText).toString(),
                     "updated note content in ##" + projectItem.getName() + "##",
                     requester,
                     ContentAction.UPDATE_NOTE_CONTENT,
@@ -344,7 +344,7 @@ public abstract class ProjectItemDaoJpa<K extends ContentModel> {
             this.notificationService.trackNoteActivity(
                 new com.bulletjournal.notifications.NoteAuditable(
                     (com.bulletjournal.repository.models.Note) projectItem,
-                    new JSONObject().put(PROJECT_CONTENT_PROPERTY, content.getText()).toString(),
+                    new JSONObject().put(CONTENT_PROPERTY, content.getText()).toString(),
                     null,
                     "deleted note content in ##" + projectItem.getName() + "##",
                     requester,

--- a/backend/src/main/java/com/bulletjournal/repository/ProjectItemDaoJpa.java
+++ b/backend/src/main/java/com/bulletjournal/repository/ProjectItemDaoJpa.java
@@ -281,14 +281,14 @@ public abstract class ProjectItemDaoJpa<K extends ContentModel> {
         this.getJpaRepository().save(projectItem);
 
         Pair<K, T> res = updateContent(requester, updateContentParams, projectItem, content, oldText);
-        String contentAfterUpdate = res.getLeft().getBaseText();
+        String newText = res.getLeft().getText();
 
         if (projectItem.getContentType() == ContentType.NOTE) {
             this.notificationService.trackNoteActivity(
                 new com.bulletjournal.notifications.NoteAuditable(
                     (com.bulletjournal.repository.models.Note) projectItem,
-                    null,
-                    new JSONObject().put(PROJECT_CONTENT_PROPERTY, contentAfterUpdate).toString(),
+                    new JSONObject().put(PROJECT_CONTENT_PROPERTY, oldText).toString(),
+                    new JSONObject().put(PROJECT_CONTENT_PROPERTY, newText).toString(),
                     "updated note content in ##" + projectItem.getName() + "##",
                     requester,
                     ContentAction.UPDATE_NOTE_CONTENT,
@@ -345,7 +345,7 @@ public abstract class ProjectItemDaoJpa<K extends ContentModel> {
             this.notificationService.trackNoteActivity(
                 new com.bulletjournal.notifications.NoteAuditable(
                     (com.bulletjournal.repository.models.Note) projectItem,
-                    new JSONObject().put(PROJECT_CONTENT_PROPERTY, content.getBaseText()).toString(),
+                    new JSONObject().put(PROJECT_CONTENT_PROPERTY, content.getText()).toString(),
                     null,
                     "deleted note content in ##" + projectItem.getName() + "##",
                     requester,

--- a/backend/src/main/java/com/bulletjournal/repository/models/NoteAuditable.java
+++ b/backend/src/main/java/com/bulletjournal/repository/models/NoteAuditable.java
@@ -5,10 +5,7 @@ import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 
 import javax.persistence.*;
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.Size;
 import java.sql.Timestamp;
-import com.bulletjournal.repository.models.Note;
 
 @Entity
 @Table(name = "note_auditables")

--- a/backend/src/main/java/com/bulletjournal/repository/models/NoteAuditable.java
+++ b/backend/src/main/java/com/bulletjournal/repository/models/NoteAuditable.java
@@ -23,6 +23,9 @@ public class NoteAuditable extends ProjectItemAuditModel {
   @OnDelete(action = OnDeleteAction.CASCADE)
   private Note note;
 
+  public NoteAuditable() {
+  }
+
   public NoteAuditable(
       Note note,
       String activity,

--- a/backend/src/main/java/com/bulletjournal/repository/models/NoteAuditable.java
+++ b/backend/src/main/java/com/bulletjournal/repository/models/NoteAuditable.java
@@ -1,48 +1,61 @@
 package com.bulletjournal.repository.models;
 
+import com.bulletjournal.contents.ContentAction;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
 import javax.persistence.*;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+import java.sql.Timestamp;
+import com.bulletjournal.repository.models.Note;
 
 @Entity
 @Table(name = "note_auditables")
-public class NoteAuditable {
+public class NoteAuditable extends ProjectItemAuditModel {
+  @Id
+  @GeneratedValue(generator = "note_auditables_generator", strategy = GenerationType.SEQUENCE)
+  @SequenceGenerator(
+      name = "note_auditables_generator",
+      sequenceName = "note_auditables_sequence",
+      initialValue = 100)
+  private Long id;
 
-    @EmbeddedId
-    private NoteAuditableKey id;
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "note_id", nullable = false)
+  @OnDelete(action = OnDeleteAction.CASCADE)
+  private Note note;
 
-    @ManyToOne
-    @MapsId("note_id")
-    @JoinColumn(name = "note_id")
-    private Note note;
+  public NoteAuditable(
+      Note note,
+      String activity,
+      String originator,
+      Timestamp activityTime,
+      ContentAction action,
+      String beforeActivity,
+      String afterActivity) {
+    this.note = note;
+    this.activity = activity;
+    this.originator = originator;
+    this.activityTime = activityTime;
+    this.action = action;
+    this.beforeActivity = beforeActivity;
+    this.afterActivity = afterActivity;
+  }
 
-    @ManyToOne
-    @MapsId("auditable_id")
-    @JoinColumn(name = "auditable_id")
-    private Auditable auditable;
+  public Note getNote() {
+    return note;
+  }
 
-    public NoteAuditable() {
-    }
+  public void setNote(Note note) {
+    this.note = note;
+  }
 
-    public NoteAuditableKey getId() {
-        return id;
-    }
+  public Long getId() {
+    return id;
+  }
 
-    public void setId(NoteAuditableKey id) {
-        this.id = id;
-    }
-
-    public Note getNote() {
-        return note;
-    }
-
-    public void setNote(Note note) {
-        this.note = note;
-    }
-
-    public Auditable getAuditable() {
-        return auditable;
-    }
-
-    public void setAuditable(Auditable auditable) {
-        this.auditable = auditable;
-    }
+  public void setId(Long id) {
+    this.id = id;
+  }
 }

--- a/backend/src/main/java/com/bulletjournal/repository/models/ProjectItemAuditModel.java
+++ b/backend/src/main/java/com/bulletjournal/repository/models/ProjectItemAuditModel.java
@@ -1,6 +1,9 @@
 package com.bulletjournal.repository.models;
 
 import com.bulletjournal.contents.ContentAction;
+import com.bulletjournal.controller.models.Activity;
+import com.bulletjournal.controller.models.ProjectItemActivity;
+import com.bulletjournal.controller.models.User;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotBlank;
@@ -76,5 +79,16 @@ public abstract class ProjectItemAuditModel extends AuditModel {
 
   public void setAction(ContentAction action) {
     this.action = action;
+  }
+
+  public ProjectItemActivity toProjectItemActivity() {
+    ProjectItemActivity projectItemActivity = new ProjectItemActivity();
+    projectItemActivity.setAction(this.getAction());
+    projectItemActivity.setActivity(this.activity);
+    projectItemActivity.setActivityTime(this.activityTime.getTime());
+    projectItemActivity.setOriginator(new User(this.originator));
+    projectItemActivity.setBeforeActivity(this.beforeActivity);
+    projectItemActivity.setAfterActivity(this.afterActivity);
+    return projectItemActivity;
   }
 }

--- a/backend/src/main/java/com/bulletjournal/repository/models/ProjectItemAuditModel.java
+++ b/backend/src/main/java/com/bulletjournal/repository/models/ProjectItemAuditModel.java
@@ -1,7 +1,6 @@
 package com.bulletjournal.repository.models;
 
 import com.bulletjournal.contents.ContentAction;
-import com.bulletjournal.controller.models.Activity;
 import com.bulletjournal.controller.models.ProjectItemActivity;
 import com.bulletjournal.controller.models.User;
 

--- a/backend/src/main/java/com/bulletjournal/repository/models/ProjectItemAuditModel.java
+++ b/backend/src/main/java/com/bulletjournal/repository/models/ProjectItemAuditModel.java
@@ -1,0 +1,80 @@
+package com.bulletjournal.repository.models;
+
+import com.bulletjournal.contents.ContentAction;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+import java.sql.Timestamp;
+
+@MappedSuperclass
+public abstract class ProjectItemAuditModel extends AuditModel {
+  @Column(name = "action", nullable = false, updatable = false)
+  protected ContentAction action;
+
+  @Column(name = "activity", nullable = false, updatable = false)
+  @Size(max = 512)
+  protected String activity;
+
+  @Column(name = "activity_time", nullable = false, updatable = false)
+  protected Timestamp activityTime;
+
+  @NotBlank
+  @Size(min = 2, max = 100)
+  @Column(length = 100, nullable = false, updatable = false)
+  protected String originator;
+
+  @Column(name = "before_activity", columnDefinition = "TEXT")
+  protected String beforeActivity;
+
+  @Column(name = "after_activity", columnDefinition = "TEXT")
+  protected String afterActivity;
+
+  public String getActivity() {
+    return activity;
+  }
+
+  public void setActivity(String activity) {
+    this.activity = activity;
+  }
+
+  public Timestamp getActivityTime() {
+    return activityTime;
+  }
+
+  public void setActivityTime(Timestamp activityTime) {
+    this.activityTime = activityTime;
+  }
+
+  public String getOriginator() {
+    return originator;
+  }
+
+  public void setOriginator(String originator) {
+    this.originator = originator;
+  }
+
+  public String getBeforeActivity() {
+    return beforeActivity;
+  }
+
+  public void setBeforeActivity(String beforeActivity) {
+    this.beforeActivity = beforeActivity;
+  }
+
+  public String getAfterActivity() {
+    return afterActivity;
+  }
+
+  public void setAfterActivity(String afterActivity) {
+    this.afterActivity = afterActivity;
+  }
+
+  public ContentAction getAction() {
+    return action;
+  }
+
+  public void setAction(ContentAction action) {
+    this.action = action;
+  }
+}

--- a/backend/src/main/java/com/bulletjournal/repository/models/TaskAuditable.java
+++ b/backend/src/main/java/com/bulletjournal/repository/models/TaskAuditable.java
@@ -1,48 +1,59 @@
 package com.bulletjournal.repository.models;
 
+import com.bulletjournal.contents.ContentAction;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
 import javax.persistence.*;
+import java.sql.Timestamp;
 
 @Entity
 @Table(name = "task_auditables")
-public class TaskAuditable {
+public class TaskAuditable extends ProjectItemAuditModel {
 
-    @EmbeddedId
-    private TaskAuditableKey id;
+  @Id
+  @GeneratedValue(generator = "task_auditables_generator", strategy = GenerationType.SEQUENCE)
+  @SequenceGenerator(
+      name = "task_auditables_generator",
+      sequenceName = "task_auditables_sequence",
+      initialValue = 100)
+  private Long id;
 
-    @ManyToOne
-    @MapsId("task_id")
-    @JoinColumn(name = "task_id")
-    private Task task;
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "task_id", nullable = false)
+  @OnDelete(action = OnDeleteAction.CASCADE)
+  private Task task;
 
-    @ManyToOne
-    @MapsId("auditable_id")
-    @JoinColumn(name = "auditable_id")
-    private Auditable auditable;
+  public TaskAuditable(
+      Task task,
+      String activity,
+      String originator,
+      Timestamp activityTime,
+      ContentAction action,
+      String beforeActivity,
+      String afterActivity) {
+    this.task = task;
+    this.activity = activity;
+    this.originator = originator;
+    this.activityTime = activityTime;
+    this.action = action;
+    this.beforeActivity = beforeActivity;
+    this.afterActivity = afterActivity;
+  }
 
-    public TaskAuditable() {
-    }
+  public Task getTask() {
+    return task;
+  }
 
-    public TaskAuditableKey getId() {
-        return id;
-    }
+  public void setTask(Task task) {
+    this.task = task;
+  }
 
-    public void setId(TaskAuditableKey id) {
-        this.id = id;
-    }
+  public Long getId() {
+    return id;
+  }
 
-    public com.bulletjournal.repository.models.Task getTask() {
-        return task;
-    }
-
-    public void setTask(com.bulletjournal.repository.models.Task task) {
-        this.task = task;
-    }
-
-    public Auditable getAuditable() {
-        return auditable;
-    }
-
-    public void setAuditable(Auditable auditable) {
-        this.auditable = auditable;
-    }
+  public void setId(Long id) {
+    this.id = id;
+  }
 }

--- a/backend/src/main/java/com/bulletjournal/repository/models/TransactionAuditable.java
+++ b/backend/src/main/java/com/bulletjournal/repository/models/TransactionAuditable.java
@@ -1,48 +1,46 @@
 package com.bulletjournal.repository.models;
 
+import com.bulletjournal.contents.ContentAction;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
 import javax.persistence.*;
+import java.sql.Timestamp;
 
 @Entity
 @Table(name = "transaction_auditables")
-public class TransactionAuditable {
+public class TransactionAuditable extends ProjectItemAuditModel {
 
-    @EmbeddedId
-    private TransactionAuditableKey id;
+  @Id
+  @GeneratedValue(
+      generator = "transaction_auditables_generator",
+      strategy = GenerationType.SEQUENCE)
+  @SequenceGenerator(
+      name = "transaction_auditables_generator",
+      sequenceName = "transaction_auditables_sequence",
+      initialValue = 100)
+  private Long id;
 
-    @ManyToOne
-    @MapsId("transaction_id")
-    @JoinColumn(name = "transaction_id")
-    private Transaction transaction;
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "transaction_id", nullable = false)
+  @OnDelete(action = OnDeleteAction.CASCADE)
+  private Transaction transaction;
 
-    @ManyToOne
-    @MapsId("auditable_id")
-    @JoinColumn(name = "auditable_id")
-    private Auditable auditable;
+  public TransactionAuditable(
+      Transaction transaction,
+      String activity,
+      String originator,
+      Timestamp activityTime,
+      ContentAction action,
+      String beforeActivity,
+      String afterActivity) {
+    this.transaction = transaction;
+    this.activity = activity;
+    this.originator = originator;
+    this.activityTime = activityTime;
+    this.action = action;
+    this.beforeActivity = beforeActivity;
+    this.afterActivity = afterActivity;
+  }
 
-    public TransactionAuditable() {
-    }
-
-    public TransactionAuditableKey getId() {
-        return id;
-    }
-
-    public void setId(TransactionAuditableKey id) {
-        this.id = id;
-    }
-
-    public Transaction getTransaction() {
-        return transaction;
-    }
-
-    public void setTransaction(Transaction transaction) {
-        this.transaction = transaction;
-    }
-
-    public Auditable getAuditable() {
-        return auditable;
-    }
-
-    public void setAuditable(Auditable auditable) {
-        this.auditable = auditable;
-    }
 }

--- a/backend/src/main/resources/db/migration/V163__project_item_auditables.sql
+++ b/backend/src/main/resources/db/migration/V163__project_item_auditables.sql
@@ -39,3 +39,48 @@ ALTER TABLE note_auditables
     ADD CONSTRAINT note_auditables_notes_id_fk
         FOREIGN KEY (note_id) REFERENCES notes
             ON DELETE CASCADE;
+
+
+
+--
+-- Name: task_auditables; Type: TABLE; Schema: public; Owner: postgres
+--
+DROP TABLE public.task_auditables;
+
+CREATE TABLE public.task_auditables (
+    id bigint not null
+        constraint task_auditables_pkey
+            primary key,
+    task_id bigint NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL,
+    activity character varying(512),
+    originator character varying(512) NOT NULL,
+    activity_time timestamp,
+    action int,
+    before_activity text,
+    after_activity text
+);
+
+ALTER TABLE public.task_auditables OWNER TO postgres;
+
+--
+-- Name: task_auditables_sequence; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.task_auditables_sequence
+    START WITH 100
+    INCREMENT BY 50
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+CREATE index task_auditables_activity_time_index
+	ON task_auditables (activity_time DESC);
+
+ALTER TABLE task_auditables
+    ADD CONSTRAINT task_auditables_tasks_id_fk
+        FOREIGN KEY (task_id) REFERENCES tasks
+            ON DELETE CASCADE;
+
+

--- a/backend/src/main/resources/db/migration/V163__project_item_auditables.sql
+++ b/backend/src/main/resources/db/migration/V163__project_item_auditables.sql
@@ -1,0 +1,41 @@
+--
+-- Name: note_auditables; Type: TABLE; Schema: public; Owner: postgres
+--
+
+DROP TABLE public.note_auditables;
+
+CREATE TABLE public.note_auditables (
+    id bigint not null
+        constraint note_auditables_pkey
+        primary key,
+    note_id bigint NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL,
+    activity character varying(512),
+    originator character varying(512) NOT NULL,
+    activity_time timestamp,
+    action int,
+    before_activity text,
+    after_activity text
+);
+
+ALTER TABLE public.note_auditables OWNER TO postgres;
+
+--
+-- Name: note_auditables_sequence; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.note_auditables_sequence
+    START WITH 100
+    INCREMENT BY 50
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+CREATE index note_auditables_activity_time_index
+	ON note_auditables (activity_time DESC);
+
+ALTER TABLE note_auditables
+    ADD CONSTRAINT note_auditables_notes_id_fk
+        FOREIGN KEY (note_id) REFERENCES notes
+            ON DELETE CASCADE;

--- a/backend/src/main/resources/db/migration/V163__project_item_auditables.sql
+++ b/backend/src/main/resources/db/migration/V163__project_item_auditables.sql
@@ -32,8 +32,8 @@ CREATE SEQUENCE public.note_auditables_sequence
     NO MAXVALUE
     CACHE 1;
 
-CREATE index note_auditables_activity_time_index
-	ON note_auditables (activity_time DESC);
+create index note_auditables_note_id_activity_time_index
+	on note_auditables (note_id asc, activity_time desc);
 
 ALTER TABLE note_auditables
     ADD CONSTRAINT note_auditables_notes_id_fk
@@ -75,8 +75,8 @@ CREATE SEQUENCE public.task_auditables_sequence
     NO MAXVALUE
     CACHE 1;
 
-CREATE index task_auditables_activity_time_index
-	ON task_auditables (activity_time DESC);
+create index task_auditables_task_id_activity_time_index
+	on task_auditables (task_id asc, activity_time desc);
 
 ALTER TABLE task_auditables
     ADD CONSTRAINT task_auditables_tasks_id_fk
@@ -118,8 +118,8 @@ CREATE SEQUENCE public.transaction_auditables_sequence
     NO MAXVALUE
     CACHE 1;
 
-CREATE index transaction_auditables_activity_time_index
-	ON transaction_auditables (activity_time DESC);
+create index transaction_auditables_transaction_id_activity_time_index
+	on transaction_auditables (transaction_id asc, activity_time desc);
 
 ALTER TABLE transaction_auditables
     ADD CONSTRAINT transaction_auditables_transactions_id_fk

--- a/backend/src/main/resources/db/migration/V163__project_item_auditables.sql
+++ b/backend/src/main/resources/db/migration/V163__project_item_auditables.sql
@@ -84,3 +84,44 @@ ALTER TABLE task_auditables
             ON DELETE CASCADE;
 
 
+
+--
+-- Name: transaction_auditables; Type: TABLE; Schema: public; Owner: postgres
+--
+DROP TABLE public.transaction_auditables;
+
+CREATE TABLE public.transaction_auditables (
+    id bigint not null
+        constraint transaction_auditables_pkey
+            primary key,
+    transaction_id bigint NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL,
+    activity character varying(512),
+    originator character varying(512) NOT NULL,
+    activity_time timestamp,
+    action int,
+    before_activity text,
+    after_activity text
+);
+
+ALTER TABLE public.transaction_auditables OWNER TO postgres;
+
+--
+-- Name: transaction_auditables_sequence; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.transaction_auditables_sequence
+    START WITH 100
+    INCREMENT BY 50
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+CREATE index transaction_auditables_activity_time_index
+	ON transaction_auditables (activity_time DESC);
+
+ALTER TABLE transaction_auditables
+    ADD CONSTRAINT transaction_auditables_transactions_id_fk
+        FOREIGN KEY (transaction_id) REFERENCES transactions
+            ON DELETE CASCADE;

--- a/backend/src/test/java/com/bulletjournal/notifications/NotificationServiceTest.java
+++ b/backend/src/test/java/com/bulletjournal/notifications/NotificationServiceTest.java
@@ -22,7 +22,9 @@ public class NotificationServiceTest {
         MockSearchIndexDaoJpa mockSearchIndexDaoJpa = new MockSearchIndexDaoJpa();
         MockRedisEtagDaoJpa mockRedisEtagDaoJpa = new MockRedisEtagDaoJpa();
         NotificationService notificationService = new NotificationService(
-                mockedNotificationDaoJpa, mockedAuditableDaoJpa, mockSearchIndexDaoJpa, mockRedisEtagDaoJpa);
+                mockedNotificationDaoJpa, mockedAuditableDaoJpa,
+                null,
+                mockSearchIndexDaoJpa, mockRedisEtagDaoJpa);
         notificationService.postConstruct();
         String originator = "BulletJournal";
         String targetUser = "u1";

--- a/backend/src/test/java/com/bulletjournal/notifications/NotificationServiceTest.java
+++ b/backend/src/test/java/com/bulletjournal/notifications/NotificationServiceTest.java
@@ -23,7 +23,6 @@ public class NotificationServiceTest {
         MockRedisEtagDaoJpa mockRedisEtagDaoJpa = new MockRedisEtagDaoJpa();
         NotificationService notificationService = new NotificationService(
                 mockedNotificationDaoJpa, mockedAuditableDaoJpa,
-                null,
                 mockSearchIndexDaoJpa, mockRedisEtagDaoJpa);
         notificationService.postConstruct();
         String originator = "BulletJournal";


### PR DESCRIPTION
In this PR, 
- update note_auditables, task_auditables, transaction_auditables table format
    - since none of them in using, drop && re-create these tables with new DDL
- track note auditable activities in notification service
- add get note history api . 
