### PR TITLE
update_sider_draging_behavior

### DIFF
--- a/frontend/src/layouts/side/side.layout.tsx
+++ b/frontend/src/layouts/side/side.layout.tsx
@@ -18,9 +18,16 @@ const SideLayout: React.FC<SiderProps> = (props) => {
     const dragHandler = useCallback(
         _.throttle((e: MouseEvent) => {
             const ele = document.getElementById('sideMenuSlider');
-            ele!.style.left = `${e.pageX}px`;
-            setWidth((prevWidth) => e.pageX);
-            props.setLayoutMarginLeft(e.pageX);
+            var pageX = e.pageX;
+            if (pageX < 50) {
+                pageX = 0;
+            }
+            else if (pageX < 249) {
+                pageX = 249;
+            }
+            ele!.style.left = `${pageX}px`;
+            setWidth((prevWidth) => pageX);
+            props.setLayoutMarginLeft(pageX);
         }, 200),
         []
     );


### PR DESCRIPTION


sider layout will mess up if we drag it < 249px now. 


https://user-images.githubusercontent.com/9599511/118692316-e69f8e00-b7d7-11eb-81cc-0c983b6685a8.mov




change the sider draging behavior, 
- once side pageX < 50px, 
    - then set it as 0
-  50px < pageX < 249px 
    - then set it as 249

 
https://user-images.githubusercontent.com/9599511/118692094-b821b300-b7d7-11eb-8ac2-0c2eb9ead062.mov

