### PR TITLE
Add allow edit project items

### DIFF
--- a/backend/src/main/java/com/bulletjournal/authz/AuthorizationService.java
+++ b/backend/src/main/java/com/bulletjournal/authz/AuthorizationService.java
@@ -119,16 +119,16 @@ public class AuthorizationService {
      */
     public boolean isContentDeletable(String owner, String requester,
                                       String projectOwner, String projectItemOwner, ProjectItemModel projectItem) {
-        if (!Objects.equals(owner, requester)
-            && !Objects.equals(projectOwner, requester)
-            && !Objects.equals(projectItemOwner, requester)) {
+        if (Objects.equals(owner, requester)
+            || Objects.equals(projectOwner, requester)
+            || Objects.equals(projectItemOwner, requester)) {
 
-            ProjectSetting projectSetting = this.projectSettingDaoJpa.getProjectSetting(projectItem.getProject().getId());
-            // projectSetting.isAllowEditContents() is true and user needs to be in project's group
-            return projectSetting.isAllowEditContents() && !notInGroup(requester, projectItem.getProject().getGroup(), true);
+            return true;
         }
 
-        return true;
+        ProjectSetting projectSetting = this.projectSettingDaoJpa.getProjectSetting(projectItem.getProject().getId());
+        // projectSetting.isAllowEditContents() is true and user needs to be in project's group
+        return projectSetting.isAllowEditContents() && !notInGroup(requester, projectItem.getProject().getGroup(), true);
     }
 
     /**
@@ -145,16 +145,16 @@ public class AuthorizationService {
     public boolean isProjectItemDeletable(String owner, String requester, String projectOwner,
                                           Long contentId, Project project) {
 
-        if (!Objects.equals(owner, requester) && !Objects.equals(projectOwner, requester)) {
-            LOGGER.info("Project Item " + contentId + " is owner by " +
-                owner + " and Project is owned by " + projectOwner + " while request is from " + requester);
-
-            ProjectSetting projectSetting = this.projectSettingDaoJpa.getProjectSetting(project.getId());
-            // projectSetting.isAllowEditProjItems() is true and user needs to be in project's group
-            return projectSetting.isAllowEditProjItems() && !notInGroup(requester, project.getGroup(), true);
+        if (Objects.equals(owner, requester) || Objects.equals(projectOwner, requester)) {
+            return true;
         }
 
-        return true;
+        LOGGER.info("Project Item " + contentId + " is owner by " +
+            owner + " and Project is owned by " + projectOwner + " while request is from " + requester);
+
+        ProjectSetting projectSetting = this.projectSettingDaoJpa.getProjectSetting(project.getId());
+        // projectSetting.isAllowEditProjItems() is true and user needs to be in project's group
+        return projectSetting.isAllowEditProjItems() && !notInGroup(requester, project.getGroup(), true);
     }
 
     private void checkAuthorizedToOperateOnBankAccount(

--- a/backend/src/main/java/com/bulletjournal/authz/AuthorizationService.java
+++ b/backend/src/main/java/com/bulletjournal/authz/AuthorizationService.java
@@ -119,14 +119,16 @@ public class AuthorizationService {
      */
     public boolean isContentDeletable(String owner, String requester,
                                       String projectOwner, String projectItemOwner, ProjectItemModel projectItem) {
-        ProjectSetting projectSetting = this.projectSettingDaoJpa.getProjectSetting(projectItem.getProject().getId());
-        if (!projectSetting.isAllowEditContents()) {
-            return Objects.equals(owner, requester) || Objects.equals(projectOwner, requester)
-                    || Objects.equals(projectItemOwner, requester);
+        if (!Objects.equals(owner, requester)
+            && !Objects.equals(projectOwner, requester)
+            && !Objects.equals(projectItemOwner, requester)) {
+
+            ProjectSetting projectSetting = this.projectSettingDaoJpa.getProjectSetting(projectItem.getProject().getId());
+            // projectSetting.isAllowEditContents() is true and user needs to be in project's group
+            return projectSetting.isAllowEditContents() && !notInGroup(requester, projectItem.getProject().getGroup(), true);
         }
 
-        // projectSetting.isAllowEditContents() is true and user needs to be in project's group
-        return !notInGroup(requester, projectItem.getProject().getGroup(), true);
+        return true;
     }
 
     /**
@@ -142,12 +144,17 @@ public class AuthorizationService {
      */
     public boolean isProjectItemDeletable(String owner, String requester, String projectOwner,
                                           Long contentId, Project project) {
+
         if (!Objects.equals(owner, requester) && !Objects.equals(projectOwner, requester)) {
             LOGGER.info("Project Item " + contentId + " is owner by " +
-                    owner + " and Project is owned by " + projectOwner + " while request is from " + requester);
-            // TODO: check project setting to see if we should fail here
+                owner + " and Project is owned by " + projectOwner + " while request is from " + requester);
+
+            ProjectSetting projectSetting = this.projectSettingDaoJpa.getProjectSetting(project.getId());
+            // projectSetting.isAllowEditProjItems() is true and user needs to be in project's group
+            return projectSetting.isAllowEditProjItems() && !notInGroup(requester, project.getGroup(), true);
         }
-        return !notInGroup(requester, project.getGroup(), true);
+
+        return true;
     }
 
     private void checkAuthorizedToOperateOnBankAccount(

--- a/backend/src/main/java/com/bulletjournal/controller/models/ProjectSetting.java
+++ b/backend/src/main/java/com/bulletjournal/controller/models/ProjectSetting.java
@@ -8,13 +8,17 @@ public class ProjectSetting {
     // Allow everyone in this BuJo to edit contents
     private boolean allowEditContents;
 
+    // Allow everyone in this BuJo to edit project items;
+    private boolean allowEditProjItems;
+
     public ProjectSetting() {
     }
 
-    public ProjectSetting(String color, boolean autoDelete, boolean allowEditContents) {
+    public ProjectSetting(String color, boolean autoDelete, boolean allowEditContents, boolean allowEditProjItems) {
         this.color = color;
         this.autoDelete = autoDelete;
         this.allowEditContents = allowEditContents;
+        this.allowEditProjItems = allowEditProjItems;
     }
 
     public boolean isAllowEditContents() {
@@ -23,6 +27,14 @@ public class ProjectSetting {
 
     public void setAllowEditContents(boolean allowEditContents) {
         this.allowEditContents = allowEditContents;
+    }
+
+    public boolean isAllowEditProjItems() {
+        return allowEditProjItems;
+    }
+
+    public void setAllowEditProjItems(boolean allowEditProjItems) {
+        this.allowEditProjItems = allowEditProjItems;
     }
 
     public String getColor() {

--- a/backend/src/main/java/com/bulletjournal/repository/ProjectSettingDaoJpa.java
+++ b/backend/src/main/java/com/bulletjournal/repository/ProjectSettingDaoJpa.java
@@ -23,7 +23,7 @@ public class ProjectSettingDaoJpa {
         ProjectSetting projectSetting = this.projectSettingRepository.findById(projectId)
                 .orElse(null);
         if (projectSetting == null) {
-            return new com.bulletjournal.controller.models.ProjectSetting(null, false, true);
+            return new com.bulletjournal.controller.models.ProjectSetting(null, false, true, true);
         }
         return projectSetting.toPresentationModel();
     }

--- a/backend/src/main/java/com/bulletjournal/repository/models/ProjectSetting.java
+++ b/backend/src/main/java/com/bulletjournal/repository/models/ProjectSetting.java
@@ -23,6 +23,9 @@ public class ProjectSetting {
     @Column(name = "allow_edit_contents")
     private boolean allowEditContents;
 
+    @Column(name = "allow_edit_proj_items")
+    private boolean allowEditProjItems;
+
     public ProjectSetting() {
     }
 
@@ -74,7 +77,16 @@ public class ProjectSetting {
         this.allowEditContents = allowEditContents;
     }
 
+    public boolean isAllowEditProjItems() {
+        return allowEditProjItems;
+    }
+
+    public void setAllowEditProjItems(boolean allowEditProjItems) {
+        this.allowEditProjItems = allowEditProjItems;
+    }
+
     public com.bulletjournal.controller.models.ProjectSetting toPresentationModel() {
-        return new com.bulletjournal.controller.models.ProjectSetting(this.color, this.autoDelete, this.allowEditContents);
+    return new com.bulletjournal.controller.models.ProjectSetting(
+        this.color, this.autoDelete, this.allowEditContents, this.allowEditProjItems);
     }
 }

--- a/backend/src/main/resources/db/migration/V177__update_project_setting_with_proj_item_editable.sql
+++ b/backend/src/main/resources/db/migration/V177__update_project_setting_with_proj_item_editable.sql
@@ -1,2 +1,2 @@
 alter table project_settings
-    add allow_edit_proj_item bool default true;
+    add allow_edit_proj_items bool default true;

--- a/backend/src/main/resources/db/migration/V177__update_project_setting_with_proj_item_editable.sql
+++ b/backend/src/main/resources/db/migration/V177__update_project_setting_with_proj_item_editable.sql
@@ -1,0 +1,2 @@
+alter table project_settings
+    add allow_edit_proj_item bool default true;

--- a/backend/src/test/java/com/bulletjournal/controller/ProjectControllerTest.java
+++ b/backend/src/test/java/com/bulletjournal/controller/ProjectControllerTest.java
@@ -1225,7 +1225,7 @@ public class ProjectControllerTest {
     }
 
     private ProjectDetails testProjectSetting(Project project) {
-        ProjectSetting projectSetting = new ProjectSetting("{\"r\":255,\"g\":224,\"b\":178,\"a\":1}", true, true);
+        ProjectSetting projectSetting = new ProjectSetting("{\"r\":255,\"g\":224,\"b\":178,\"a\":1}", true, true, true);
         ResponseEntity<ProjectDetails> response = this.restTemplate.exchange(
                 ROOT_URL + randomServerPort + ProjectController.PROJECT_SETTINGS_ROUTE,
                 HttpMethod.PUT,
@@ -1238,7 +1238,7 @@ public class ProjectControllerTest {
         assertEquals("{\"r\":255,\"g\":224,\"b\":178,\"a\":1}", p.getProjectSetting().getColor());
         assertTrue(p.getProjectSetting().isAutoDelete());
 
-        projectSetting = new ProjectSetting("{\"r\":209,\"g\":196,\"b\":233,\"a\":1}", false, true);
+        projectSetting = new ProjectSetting("{\"r\":209,\"g\":196,\"b\":233,\"a\":1}", false, true, true);
         response = this.restTemplate.exchange(
                 ROOT_URL + randomServerPort + ProjectController.PROJECT_SETTINGS_ROUTE,
                 HttpMethod.PUT,
@@ -1255,7 +1255,7 @@ public class ProjectControllerTest {
     }
 
     private void testGetProjectSettingsMultiple(List<Project> projects) {
-        ProjectSetting projectSetting = new ProjectSetting("{\"r\":255,\"g\":224,\"b\":178,\"a\":1}", true, true);
+        ProjectSetting projectSetting = new ProjectSetting("{\"r\":255,\"g\":224,\"b\":178,\"a\":1}", true, true, true);
         ResponseEntity<ProjectDetails> response = this.restTemplate.exchange(
                 ROOT_URL + randomServerPort + ProjectController.PROJECT_SETTINGS_ROUTE,
                 HttpMethod.PUT,
@@ -1267,7 +1267,7 @@ public class ProjectControllerTest {
         assertEquals("{\"r\":255,\"g\":224,\"b\":178,\"a\":1}", p.getProjectSetting().getColor());
         assertTrue(p.getProjectSetting().isAutoDelete());
 
-        projectSetting = new ProjectSetting("{\"r\":209,\"g\":196,\"b\":233,\"a\":1}", false, true);
+        projectSetting = new ProjectSetting("{\"r\":209,\"g\":196,\"b\":233,\"a\":1}", false, true, true);
         response = this.restTemplate.exchange(
                 ROOT_URL + randomServerPort + ProjectController.PROJECT_SETTINGS_ROUTE,
                 HttpMethod.PUT,
@@ -1279,7 +1279,7 @@ public class ProjectControllerTest {
         assertEquals("{\"r\":209,\"g\":196,\"b\":233,\"a\":1}", p.getProjectSetting().getColor());
         assertFalse(p.getProjectSetting().isAutoDelete());
 
-        projectSetting = new ProjectSetting("{\"r\":220,\"g\":231,\"b\":117,\"a\":1}", true, true);
+        projectSetting = new ProjectSetting("{\"r\":220,\"g\":231,\"b\":117,\"a\":1}", true, true, true);
         response = this.restTemplate.exchange(
                 ROOT_URL + randomServerPort + ProjectController.PROJECT_SETTINGS_ROUTE,
                 HttpMethod.PUT,


### PR DESCRIPTION
In this PR, 
- Add allow edit project items (column && logic)
- Reverse `isContentDeletable` logic, checking if `requester` is part of `owners` first. if not, then getProjectSetting and check isAllowEditContents field value. Slightly reducing # of db queries